### PR TITLE
Py3 fixes1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.egg-info/

--- a/rdfextras/sparql/operators.py
+++ b/rdfextras/sparql/operators.py
@@ -31,13 +31,17 @@ from rdflib.namespace import Namespace, XSD
 from rdfextras.sparql.graph import _createResource
 from rdfextras.sparql import _questChar, Debug
 
+# We replace str with a custom function below. This messes things up after
+# 2to3 conversion, which replaces basestring with str. At some point, we should
+# clean this up properly - i.e. don't override the builtin str.
+str_ = basestring
 
 ##
 # Boolean test whether this is a a query string or not
 # @param v the value to be checked
 # @return True if it is a query string
 def queryString(v) :
-    return isinstance(v,basestring) and len(v) != 0 and v[0] == _questChar
+    return isinstance(v,str_) and len(v) != 0 and v[0] == _questChar
 
 ##
 # Return the value in a literal, making on the fly conversion on datatype (using the datatypes that are implemented)

--- a/rdfextras/sparql/parser.py
+++ b/rdfextras/sparql/parser.py
@@ -132,16 +132,16 @@ if DEBUG:
 def composition(callables):
     def composed(arg):
         result = arg
-        for callable in callables:
-            result = callable(result)
+        for func in callables:
+            result = func(result)
         return result
     return composed
 
 def composition2(callables):
     def composed(*args):
         result = args
-        for callable in callables:
-            result = [callable(*result)]
+        for func in callables:
+            result = [func(*result)]
         return result[0]
     return composed
 

--- a/rdfextras/sparql/parser.py
+++ b/rdfextras/sparql/parser.py
@@ -198,7 +198,7 @@ def refer_component(component, initial_args=None, projection=None, **kwargs):
         def apply(results):
             if DEBUG:
                 log.debug(component)
-                debug(results)
+                log.debug(results)
             return component(*results.asList(), **kwargs)
     else:
         def apply(results):

--- a/rdfextras/sparql/query.py
+++ b/rdfextras/sparql/query.py
@@ -12,6 +12,12 @@ from rdfextras.sparql import SPARQLError
 from rdfextras.sparql.graph import SPARQLGraph
 from rdfextras.sparql.graph import GraphPattern
 
+try:
+    # Used in Python 2.7 and 3.x for cmp_to_key
+    import functools
+except ImportError:
+    functools = None
+
 class SessionBNode(BNode):
     """
     Special 'session' BNodes.  I.e., BNodes at the query side which refer to 
@@ -994,7 +1000,12 @@ class Query :
                                 elif val1 < val2 : return 1
                 return 0
         # get the full Binding sorted
-        fullBinding.sort(_sortBinding)
+        try:
+            keyfunc = functools.cmp_to_key(_sortBinding)
+            fullBinding.sort(key=keyfunc)
+        except AttributeError:
+            # Python < 2.7
+            fullBinding.sort(cmp=_sortBinding)
         
         # remember: _processResult turns the expansion results (an array of dictionaries)
         # into an array of tuples in the right, original order

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -18,7 +18,7 @@ class TestSparqlResultsFormats(unittest.TestCase):
         r=rdflib.query.Result.parse(StringIO(s), format=format)
         s=r.serialize(format=format)
         #print s
-        r2=rdflib.query.Result.parse(StringIO(s.encode('utf-8')), format=format)
+        r2=rdflib.query.Result.parse(StringIO(s.decode('utf-8')), format=format)
         self.assertEqual(r,r2)
 
     

--- a/test/test_sparql/test_not_equals.py
+++ b/test/test_sparql/test_not_equals.py
@@ -17,13 +17,13 @@ def testSPARQLNotEquals():
        @prefix    : <http://example.org/> .
        @prefix rdf: <%s> .
        :foo rdf:value 1.
-       :bar rdf:value 2.""") % RDF.uri), format="n3")
-    rt = graph.query(b("""SELECT ?node 
+       :bar rdf:value 2.""" % RDF.uri)), format="n3")
+    rt = graph.query("""SELECT ?node 
                             WHERE {
                                     ?node rdf:value ?val.
                                     FILTER (?val != 1)
-                                   }"""),
-                           initNs={b('rdf'): RDF.uri},
+                                   }""",
+                           initNs={'rdf': RDF.uri},
                            DEBUG=False)
     for row in rt:        
         item = row[0]

--- a/test/test_sparql/test_sparql_json_results.py
+++ b/test/test_sparql/test_sparql_json_results.py
@@ -107,13 +107,15 @@ class TestSparqlJsonResults(unittest.TestCase):
 
     def _query_result_contains(self, query, correct):
         results = self.graph.query(query)
-        result_json = json.loads(results.serialize(format='json'))
+        result_json = json.loads(results.serialize(format='json').decode('utf-8'))
 
         msg = "Expected:\n %s \n- to contain:\n%s" % (result_json, correct)
-        self.failUnless(result_json["head"]==correct["head"], msg)
+        self.assertEqual(result_json["head"], correct["head"], msg)
 
-        result_bindings = sorted(result_json["results"]["bindings"])
-        correct_bindings = sorted(correct["results"]["bindings"])
+        # Sort by repr - rather a hack, but currently the best way I can think
+        # of to ensure the results are in the same order.
+        result_bindings = sorted(result_json["results"]["bindings"], key=repr)
+        correct_bindings = sorted(correct["results"]["bindings"], key=repr)
         msg = "Expected:\n %s \n- to contain:\n%s" % (result_bindings, correct_bindings)
         self.failUnless(result_bindings==correct_bindings, msg)
 

--- a/test/test_sparql/test_sparql_limit.py
+++ b/test/test_sparql/test_sparql_limit.py
@@ -67,7 +67,7 @@ class TestLimit(unittest.TestCase):
            graph.parse(StringIO(test_data2), format="n3")
            results = list(graph.query(test_query2,DEBUG=True))
            print graph.query(test_query2).serialize(format='xml')
-           self.assertEqual(len(results) == 1)
+           self.assertEqual(len(results), 1)
            for title,price in results:    
                self.assertTrue(title in [Literal("Java Tutorial"),
                                          Literal("COBOL Tutorial")])    

--- a/test/test_sparql/test_sparql_limit.py
+++ b/test/test_sparql/test_sparql_limit.py
@@ -60,16 +60,16 @@ class TestLimit(unittest.TestCase):
         graph.parse(StringIO(test_data), format="n3")
         results = graph.query(test_query,DEBUG=True)
         print len(results)
-        self.failUnless(len(results) == 2)
+        self.assertEqual(len(results), 2)
         
     def testLimit2(self):
            graph = ConjunctiveGraph(plugin.get('IOMemory',Store)())
            graph.parse(StringIO(test_data2), format="n3")
            results = list(graph.query(test_query2,DEBUG=True))
            print graph.query(test_query2).serialize(format='xml')
-           self.failUnless(len(results) == 1)
+           self.assertEqual(len(results) == 1)
            for title,price in results:    
-               self.failUnless(title in [Literal("Java Tutorial"),
+               self.assertTrue(title in [Literal("Java Tutorial"),
                                          Literal("COBOL Tutorial")])    
 
 if __name__ == "__main__":

--- a/test/test_store/test_served_sparql_store.py
+++ b/test/test_store/test_served_sparql_store.py
@@ -2,7 +2,11 @@ import unittest
 import threading
 import rdflib
 import rdfextras
-import rdfextras.web.endpoint
+try:
+    import rdfextras.web.endpoint
+    webserver = True
+except:
+    webserver = False
 import rdfextras.store.SPARQL
 
 rdflib.plugin.register('sparql', rdflib.query.Processor,
@@ -16,8 +20,11 @@ rdflib.plugin.register('xml', rdflib.query.ResultSerializer,
 
 
 class TestSPARQLStore(unittest.TestCase): 
-
-    def testSPARQLStore(self): 
+    def testSPARQLStore(self):
+        # The mechanisms to properly skip tests are only in Python 2.7/3.1
+        if not webserver:
+            return "Skipped test - web server not available."
+        
         g=rdflib.Graph()
 
         data="""<http://example.org/book/book1> <http://purl.org/dc/elements/1.1/title> "SPARQL Tutorial" .

--- a/test/test_store/test_store.py
+++ b/test/test_store/test_store.py
@@ -6,7 +6,7 @@ from rdflib import URIRef
 from rdflib.store import NodePickler
 
 
-canned_result = """\
+canned_result = u"""\
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
    xmlns:ns1="http://example.org/foo#"
@@ -16,7 +16,7 @@ canned_result = """\
     <ns1:bar2 rdf:resource="http://example.org/foo#bar3"/>
   </rdf:Description>
 </rdf:RDF>
-"""
+""".encode('utf-8')
 
 class UtilTestCase(unittest.TestCase):
     storetest = True
@@ -34,7 +34,7 @@ class UtilTestCase(unittest.TestCase):
         g.add((URIRef("http://example.org/foo#bar1"),
                URIRef("http://example.org/foo#bar2"),
                URIRef("http://example.org/foo#bar3")))
-        assert g.serialize() == canned_result
+        self.assertEqual(g.serialize(), canned_result)
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
With these changes, all but one of the tests pass on Python 3.2 (the remaining failure is in test_sparql_date_filter, which I haven't got round to debugging yet).

One test is kind of skipped, because it requires a server using Flask, which isn't available on Python 3 yet. If this is important, we can probably convert it to one of the web frameworks that does support Python 3 (e.g. tornado, cherry, bottle).
