### PR TITLE
Py3 fixes2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ coverage/
 /.hgtags
 /.hgignore
 /.gitignore
-/__pycache__/
+__pycache__/
 nosetests.xml

--- a/rdfextras/sparql/components.py
+++ b/rdfextras/sparql/components.py
@@ -695,6 +695,12 @@ class PropertyValue(object):
     def __eq__(self, other):
         return (self.property == other.property and
                 self.objects == other.objects)
+    
+    def __hash__(self):
+        h = hash(self.property)  
+        for o in self.objects:
+            h ^= hash(o)
+        return h
 
 class ParsedConstrainedTriples(object):
     """

--- a/test/test_sparql/test_short_forms.py
+++ b/test/test_sparql/test_short_forms.py
@@ -3,6 +3,7 @@ from rdflib.store import Store
 from rdflib import plugin
 from rdflib.parser import StringInputSource
 from rdflib.graph import Graph
+from rdflib.py3compat import b
 import unittest,sys
 
 import rdflib
@@ -40,12 +41,12 @@ class TestSPARQLAbbreviations(unittest.TestCase):
     def setUp(self):
         NS = u"http://example.org/"
         self.graph = Graph(store)
-        self.graph.parse(StringInputSource("""
+        self.graph.parse(StringInputSource(b("""
            @prefix    : <http://example.org/> .
            @prefix rdf: <%s> .
            @prefix rdfs: <%s> .
            [ :prop :val ].
-           [ a rdfs:Class ]."""%(RDF,RDFS)), format="n3")
+           [ a rdfs:Class ]."""%(RDF,RDFS))), format="n3")
 
     def testTypeAbbreviation(self):
         query = """SELECT ?subj WHERE { ?subj a rdfs:Class }"""

--- a/test/test_sparql/test_sparql_xml_results.py
+++ b/test/test_sparql/test_sparql_xml_results.py
@@ -1,5 +1,6 @@
 import rdflib
 from rdflib.graph import ConjunctiveGraph
+from rdflib.py3compat import b
 from StringIO import StringIO
 import re
 import unittest
@@ -35,15 +36,17 @@ SELECT ?s ?o WHERE { ?s ?p ?o . }
 expected_fragments = [
     #u"""<sparql:sparql xmlns="http://www.w3.org/2005/sparql-results#"><sparql:head>""",
 
-    u"""</sparql:head><sparql:results>""",
+    b("</sparql:head><sparql:results>"),
 
-    u"""<sparql:binding name="s"><sparql:uri>http://example.org/word</sparql:uri></sparql:binding>""",
+    b('<sparql:binding name="s"><sparql:uri>http://example.org/word</sparql:uri></sparql:binding>'),
 
-    u"""<sparql:binding name="o"><sparql:bnode>""",
+    b('<sparql:binding name="o"><sparql:bnode>'),
 
-    u"""<sparql:binding name="o"><sparql:literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</sparql:literal></sparql:binding>""",
+    b('<sparql:binding name="o"><sparql:literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</sparql:literal></sparql:binding>'),
 
-    u"""<sparql:result><sparql:binding name="s"><sparql:uri>http://example.org/word</sparql:uri></sparql:binding><sparql:binding name="o"><sparql:literal xml:lang="en">Word</sparql:literal></sparql:binding></sparql:result>"""
+    b('<sparql:result><sparql:binding name="s"><sparql:uri>http://example.org/word</sparql:uri>'
+      '</sparql:binding><sparql:binding name="o"><sparql:literal xml:lang="en">Word</sparql:literal>'
+      '</sparql:binding></sparql:result>')
 ]
 
 
@@ -73,8 +76,8 @@ class TestSparqlXmlResults(unittest.TestCase):
             self.failUnless(frag in result_xml)
 
 
-def normalize(s, exp=re.compile(r'\s+', re.MULTILINE)):
-    return exp.sub(' ', s)
+def normalize(s, exp=re.compile(b(r'\s+'), re.MULTILINE)):
+    return exp.sub(b(' '), s)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes for a couple more tests that it seems are only run by run_tests.py, not by nosetests.

The datetime issue is still there, unfortunately. It's the one that involves comparing datetimes to raw strings (https://github.com/RDFLib/rdfextras/blob/master/test/test_sparql/test_sparql_date_filter.py#L39) - I've no idea which bit of the code is supposed to make that comparison work.
