### PR TITLE
Bug encountered at rdfextras/utils/termutils.py

### DIFF
--- a/rdfextras/utils/termutils.py
+++ b/rdfextras/utils/termutils.py
@@ -193,7 +193,7 @@ def type2TermCombination(member,klass,context):
         return rt
     except:
         raise Exception("Unable to persist" + \
-                        "classification triple: %s %s %s" % \
+                        "classification triple: %s %s %s %s" % \
                                     (member,'rdf:type',klass,context))
 
 


### PR DESCRIPTION
Hello,

I have encountered a bug at rdfextras/utils/termutils.py, a "%s" was missing at line 197:

raise Exception("Unable to persist" + \
                        "classification triple: %s %s %s" % \
                                    (member,'rdf:type',klass,context))

There are four arguments at the tuple.
