### PR TITLE
Bug encountered at rdfextras/store/AbstractSQLStore.py

### DIFF
--- a/rdfextras/store/AbstractSQLStore.py
+++ b/rdfextras/store/AbstractSQLStore.py
@@ -153,7 +153,7 @@ def createTerm(termString, termType, store, objLanguage=None, objDatatype=None):
             # rt = Literal(termString, objLanguage, objDatatype)
             # store.literalCache[((termString, objLanguage, objDatatype))] = rt
             if objLanguage and not objDatatype:
-                rt = Literal(termString, language=objLanguage)
+                rt = Literal(termString, lang=objLanguage)
                 store.literalCache[((termString, objLanguage))] = rt
             elif objDatatype and not objLanguage:
                 rt = Literal(termString, datatype=objDatatype)


### PR DESCRIPTION
I have encountered a bug at this file, at line 156.

rt = Literal(termString, language=objLanguage)

The name of the parameter is 'lang' instead of 'language'.
